### PR TITLE
Remove allowBackup="true"

### DIFF
--- a/konfetti/src/main/AndroidManifest.xml
+++ b/konfetti/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
+    <application android:label="@string/app_name"
         android:supportsRtl="true">
 
     </application>


### PR DESCRIPTION
This is to allow projects to use this library without the need for tools:replace="android:allowBackup"